### PR TITLE
Promisify play method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ export default class UIfx {
     this.validateVolume = validateVolume;
   }
 
-  play = volume => {
+  play = volume => new Promise((resolve, reject) => {
     this.validateVolume(volume);
 
     const audioElement = new Audio(this.file);
@@ -79,11 +79,11 @@ export default class UIfx {
 
     audioElement.addEventListener("loadeddata", () => {
       audioElement.volume = volume >= 0 && volume <= 1 ? volume : this.volume;
-      audioElement.play();
+      audioElement.play().then(resolve).catch(reject);
     });
 
-    return this;
-  };
+    audioElement.addEventListener("error", reject);
+  });
 
   setVolume = volume => {
     this.validateVolume(volume);


### PR DESCRIPTION
Promisify play method so to be able to catch errors.

Fixes https://github.com/wle8300/uifx/issues/9

To test:

```
const NofifyAudio = new UIfx('/media/orders_notify.mp3');

NofifyAudio.play().catch(err => console.warn('UIfx play error', err));

// We can now skip the whole message like this:
// NofifyAudio.play().catch(() => {});
```

It should echo our `catch` console warning instead of the direct DOM error:

```
UIfx play error DOMException: play() failed because the user didn't interact with the document first.
```