### PR TITLE
Fix - Chrome autoplay policy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,14 @@ export default class UIfx {
 
     audioElement.addEventListener("loadeddata", () => {
       audioElement.volume = volume >= 0 && volume <= 1 ? volume : this.volume;
-      audioElement.play();
+      var audioElementPromise = audioElement.play();
+      audioElementPromise
+        .then(() => {
+          // autoplay started, everyting is ok
+        })
+        .catch(error => {
+          // autoplay was prevented, don't display any error messages
+        });
     });
 
     return this;


### PR DESCRIPTION
Added a little bit of code in the `play()` function to comply with the Chrome autoplay policy.
Now errors don't pop out in the console whenever the autoplay is prevented.

Referring to the [issue I opened](https://github.com/wle8300/uifx/issues/12) - it is now fixed.